### PR TITLE
make ExecStop wait for pid to die

### DIFF
--- a/src/rpm/php/hestia-php.service
+++ b/src/rpm/php/hestia-php.service
@@ -8,7 +8,7 @@ Type=forking
 PIDFile=/var/run/hestia-php.pid
 ExecStart=/usr/local/hestia/php/sbin/hestia-php --fpm-config /usr/local/hestia/php/etc/php-fpm.conf
 ExecReload=/bin/sh -c "/bin/kill -s HUP $(/bin/cat /var/run/hestia-php.pid)"
-ExecStop=/bin/sh -c "/bin/kill -s TERM $(/bin/cat /var/run/hestia-php.pid)"
+ExecStop=/usr/bin/php -r '$pid=(int)file_get_contents("/var/run/hestia-php.pid");posix_kill($pid,SIGTERM);while(posix_kill($pid,0)){sleep(0);}'
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment HOSTNAME=$(/usr/bin/hostname)"
 Environment="HESTIA=/usr/local/hestia"
 


### PR DESCRIPTION
the previous ExecStop would send the SIGTERM signal and return immediately. the new ExecStop will send SIGTERM then wait until the pid actually dies, similar to Debian/Ubuntu's "start-stop-daemon --stop --quiet --pidfile $NGINX_PID --retry 5 --oknodo --exec $NGINX_DAEMON".
sleep(0) is a neat little hack basically do the equivalent of pthread_yield(), turns the CPU usage from 100%-of-1-core to 15%-of-1-core, sleeping very fast.. which is required because there is a race condition here that is very hard to fix: if the pid is re-used between scans, we won't notice the pid has actually died and been re-used.

Even "killall -w" is susceptible to this race condition bug, and the fact that even killall haven't fixed it, is an indication that fixing this race condition bug is probably very difficult, the easiest course of action is probably to sleep very little, ie pthread_yield(); / sleep(0);

upstream PR: https://github.com/hestiacp/hestiacp/pull/2772